### PR TITLE
Add config to podspec to exclude arm64 architecture when building

### DIFF
--- a/SendBirdCalls.podspec
+++ b/SendBirdCalls.podspec
@@ -13,4 +13,6 @@ Pod::Spec.new do |s|
   s.ios.frameworks = ["UIKit", "Foundation", "PushKit", "WebRTC", "AVKit", "MediaPlayer", "Network", "CoreTelephony", "VideoToolbox"]
   s.requires_arc = true
   s.dependency "SendBirdWebRTC", "~> 1.3.0"
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
This PR adds a configuration to exclude arm64 architecture when building. Our SDK does not support arm64. 
Please refere to https://stackoverflow.com/questions/63607158/xcode-12-building-for-ios-simulator-but-linking-in-object-file-built-for-ios/63955114#63955114