### PR TITLE
Release 1.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 xcuserdata/
 DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+*.xcframework
+*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+### 1.12.0 (Apr 9, 2026)
+- Rebuilt with **Xcode 26** to comply with Apple's App Store submission requirement,
+  effective late April 2026, which mandates that all apps be built using Xcode 26 or later.
+- No functional changes or API modifications are included in this release.
+
+> **Note for Xcode 16 users:** This release is compiled with Xcode 26 and may not be
+> compatible with Xcode 16 build environments. If you are still on Xcode 16, please
+> continue using the previous version.
+
 ### 1.11.2 (Mar 19, 2026)
 * Fixed a thread safety crash in `DirectCall` when `callLog` is accessed concurrently during call termination.  
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,13 +11,13 @@ let package = Package(
             targets: ["SendBirdCallsTarget"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/sendbird/sendbird-webrtc-ios", "1.9.0"..<"1.10.0")
+        .package(url: "https://github.com/sendbird/sendbird-webrtc-ios", "1.10.0"..<"1.11.0")
     ],
     targets: [
         .binaryTarget(
             name: "SendBirdCalls",
-            url: "https://github.com/sendbird/sendbird-calls-ios/releases/download/1.11.2/SendBirdCalls.xcframework.zip",
-            checksum: "efd0e4f90f3c91f0e26d60bc68ef21d19dc49f6483f87b414f61d3593c5ca1dd"
+            url: "https://github.com/sendbird/sendbird-calls-ios/releases/download/1.12.0/SendBirdCalls.xcframework.zip",
+            checksum: "852de54fa23473d2b4fb68e8fc4b23749c5152347abbd528f1f0672c36dd6a94"
         ),
         .target(name: "SendBirdCallsTarget",
                 dependencies: [


### PR DESCRIPTION
- Rebuilt with **Xcode 26** to comply with Apple's App Store submission requirement,
  effective late April 2026, which mandates that all apps be built using Xcode 26 or later.
- No functional changes or API modifications are included in this release.

> **Note for Xcode 16 users:** This release is compiled with Xcode 26 and may not be
> compatible with Xcode 16 build environments. If you are still on Xcode 16, please
> continue using the previous version.