### PR TITLE
Release/1.12.2 -> master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### 1.12.2 (Jul 16, 2026)
+* Fixed an issue in Group Calls where a remote participant could remain stuck in the ENTERED state when two users called `room.enter()` almost simultaneously, resulting in missing audio/video.
+
 ### 1.12.1 (Jul 7, 2026)
 * Fixed a thread-safety crash that could occur during a VoIP push cold launch when incoming call events were processed before authentication completed.
 

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendBirdCalls",
-            url: "https://github.com/sendbird/sendbird-calls-ios/releases/download/1.12.1/SendBirdCalls.xcframework.zip",
-            checksum: "35d14939982c911fa7bf241b0e5946e2f2c53a8c62795ce557eb882a579c3952"
+            url: "https://github.com/sendbird/sendbird-calls-ios/releases/download/1.12.2/SendBirdCalls.xcframework.zip",
+            checksum: "114425c9b998ee05f4891f9dabb1f84e55d5ae83931c7aa7216f9cd99280c9c9"
         ),
         .target(name: "SendBirdCallsTarget",
                 dependencies: [


### PR DESCRIPTION
## Release 1.12.2

- Update `Package.swift` binary target to 1.12.2 (download URL + checksum `114425c9b998ee05f4891f9dabb1f84e55d5ae83931c7aa7216f9cd99280c9c9`)
- Add a 1.12.2 entry to `CHANGELOG.md` (Group Call `room.enter()` race fix, CLNP-8489)

> The binary (`SendBirdCalls.xcframework.zip`) will be uploaded as the 1.12.2 GitHub release asset after merge, matching the checksum above.
